### PR TITLE
Don't disable IPv6

### DIFF
--- a/Scripts/interfaces.ps1
+++ b/Scripts/interfaces.ps1
@@ -9,9 +9,6 @@ Write-Host "Disable NetBios for all interfaces"
 $regkey = "HKLM:SYSTEM\CurrentControlSet\services\NetBT\Parameters\Interfaces"
 Get-ChildItem $regkey | ForEach-Object { Set-ItemProperty -Path "$regkey\$($_.pschildname)" -Name NetbiosOptions -Value 2 -Verbose}
 
-Write-Host "Disable ipv6 for all interfaces"
-Disable-NetAdapterBinding -Name "*" -ComponentID ms_tcpip6
-
 Write-Host "Disable LLDP for all interfaces"
 Disable-NetAdapterBinding -Name "*" -ComponentID ms_lldp
 


### PR DESCRIPTION
IPv6 exist since 24 years now and is the future: https://en.wikipedia.org/wiki/IPv6
Don't block that more and more used protocol. IPv4 is deprecated 

Also Windows has by default activated Privacy Extensions for IPv6: https://tools.ietf.org/html/rfc4941